### PR TITLE
Remove Second-hand menu item

### DIFF
--- a/_data/settings.yml
+++ b/_data/settings.yml
@@ -14,8 +14,6 @@ menu_settings:
       url: '/sk/blog'
     - title: 'Movies'
       url: '/movies' 
-    - title: 'Second-hand'
-      url: '/secondhand'   
     - title: 'About'
       url: '/about'
     - title: 'Contact'


### PR DESCRIPTION
## Summary
- remove the Second-hand link from navigation

## Testing
- `bundle install --path vendor/bundle` *(fails: 403 Forbidden)*
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68453ea26c7c833086a51b5dbff42af9